### PR TITLE
feat: Implement drag and drop functionality for blog blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "next-auth": "^4.24.11",
         "react": "^18.3.1",
         "react-apexcharts": "^1.7.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.5",
         "react-hook-form": "^7.53.2",
@@ -1207,6 +1209,24 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
+    },
     "node_modules/@react-spring/animated": {
       "version": "9.7.5",
       "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
@@ -1890,7 +1910,7 @@
       "version": "20.17.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
       "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -3160,6 +3180,26 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
+    "node_modules/dnd-core/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -6520,6 +6560,45 @@
         "react": ">=0.13"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -7644,7 +7723,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "next-auth": "^4.24.11",
     "react": "^18.3.1",
     "react-apexcharts": "^1.7.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.53.2",

--- a/src/app/(public)/blog/blocksPanel.tsx
+++ b/src/app/(public)/blog/blocksPanel.tsx
@@ -6,14 +6,15 @@ import {
   layoutBlocks,
 } from "@/constants/pagebuilder/blocks";
 import { BlockForm, blocksForm } from "@/constants/pagebuilder/formFields";
-import { Block, TabProps } from "@/types/blog";
+import { Block, BlockButton, TabProps } from "@/types/blog";
 import { generateId } from "@/util";
 import { addItem } from "@/util/blog";
 import { Button } from "@mui/material";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { blockStyles } from "./constants/blocks.styles";
 import templates from "./constants/templates.json";
 import Image from "next/image";
+import { useDrag } from "react-dnd";
 
 const BlocksPanel: React.FC<TabProps> = ({
   selectedBlock,
@@ -117,7 +118,7 @@ const BlocksPanel: React.FC<TabProps> = ({
                     </p>
                   </div>
                 </button>
-                <p className="text-nowrap w-[80px]">Template ({index + 1})</p>
+                <p className="w-[80px] text-nowrap">Template ({index + 1})</p>
               </div>
             ))}
           </div>
@@ -126,16 +127,11 @@ const BlocksPanel: React.FC<TabProps> = ({
           <h3 className="mb-2 text-sm font-medium">Basic Elements</h3>
           <div className="grid grid-cols-2 gap-2">
             {basicBlocks.map((item, index) => (
-              <div key={item.id}>
-                <Button
-                  variant="outlined"
-                  className="w-full justify-start"
-                  onClick={() => handleAddBlock(item.id)}
-                >
-                  {item.icon}
-                  {item.label}
-                </Button>
-              </div>
+              <AddBlockItem
+                key={index}
+                item={item}
+                onClick={() => handleAddBlock(item.id)}
+              />
             ))}
           </div>
         </div>
@@ -144,16 +140,11 @@ const BlocksPanel: React.FC<TabProps> = ({
           <h3 className="mb-2 text-sm font-medium">Layout Structures</h3>
           <div className="grid grid-cols-2 gap-2">
             {layoutBlocks.map((item, index) => (
-              <div key={item.id}>
-                <Button
-                  variant="outlined"
-                  className="w-full justify-start"
-                  onClick={() => handleAddBlock(item.id)}
-                >
-                  {item.icon}
-                  {item.label}
-                </Button>
-              </div>
+              <AddBlockItem
+                key={index}
+                item={item}
+                onClick={() => handleAddBlock(item.id)}
+              />
             ))}
           </div>
         </div>
@@ -162,16 +153,11 @@ const BlocksPanel: React.FC<TabProps> = ({
           <h3 className="mb-2 text-sm font-medium">Content Blocks</h3>
           <div className="grid grid-cols-2 gap-2">
             {contentBlocks.map((item, index) => (
-              <div key={item.id}>
-                <Button
-                  variant="outlined"
-                  className="w-full justify-start"
-                  onClick={() => handleAddBlock(item.id)}
-                >
-                  {item.icon}
-                  {item.label}
-                </Button>
-              </div>
+              <AddBlockItem
+                key={index}
+                item={item}
+                onClick={() => handleAddBlock(item.id)}
+              />
             ))}
           </div>
         </div>
@@ -181,3 +167,37 @@ const BlocksPanel: React.FC<TabProps> = ({
 };
 
 export default BlocksPanel;
+
+const AddBlockItem: React.FC<{ item: BlockButton; onClick: () => void }> = ({
+  item,
+  onClick,
+}) => {
+  const ref = useRef(null);
+
+  const [{ isDragging }, drag] = useDrag({
+    type: item.id,
+    item: {
+      type: item.id,
+      id: item.id,
+    },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  });
+
+  const opacity = isDragging ? 0 : 1;
+  drag(ref);
+
+  return (
+    <div ref={ref} style={{ opacity }} key={item.id}>
+      <Button
+        variant="outlined"
+        className="w-full justify-start"
+        onClick={onClick}
+      >
+        {item.icon}
+        {item.label}
+      </Button>
+    </div>
+  );
+};

--- a/src/app/(public)/blog/blog.ts
+++ b/src/app/(public)/blog/blog.ts
@@ -116,6 +116,9 @@ export const onDragEndHandler = (
   result: DropResult,
 ): Block[] => {
   const { source, destination, draggableId } = result;
+  console.log("🚀 ~ source:", source)
+  console.log("🚀 ~ draggableId:", draggableId)
+  console.log("🚀 ~ destination:", destination)
 
   // If there's no destination, return original blocks
   if (!destination) return blocks;

--- a/src/app/(public)/blog/components/dropzone.tsx
+++ b/src/app/(public)/blog/components/dropzone.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { useDrop } from "react-dnd";
+import { cn } from "@/util";
+import { Block } from "@/types/blog";
+
+const ACCEPTS: Block["type"][] = [
+  "h1",
+  "h2",
+  "h3",
+  "text",
+  "paragraph",
+  "image",
+  "button",
+  "html",
+  "divider",
+  "container",
+  "grid",
+  "flex-row",
+  "flex-column",
+  "quote",
+  "code",
+  "video",
+];
+
+type DropZoneData = {
+  path: string;
+  childrenCount: number;
+};
+
+type DragItem = Block & { path: string };
+
+type DropZoneProps = {
+  data: DropZoneData;
+  onDrop: (data: DropZoneData, item: DragItem) => void;
+  isLast?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+};
+
+const DropZone: React.FC<DropZoneProps> = ({
+  data,
+  onDrop,
+  isLast = false,
+  className,
+  children,
+}) => {
+  const [{ isOver, canDrop }, drop] = useDrop<
+    DragItem,
+    void,
+    { isOver: boolean; canDrop: boolean }
+  >({
+    accept: ACCEPTS,
+    drop: (item) => {
+      onDrop(data, item);
+    },
+    canDrop: (item) => {
+      const dropZonePath = data.path;
+      const splitDropZonePath = dropZonePath.split("-");
+      const itemPath = item.path;
+
+      if (!itemPath) return true;
+
+      const splitItemPath = itemPath.split("-");
+
+      if (itemPath === dropZonePath) return false;
+
+      if (splitItemPath.length === splitDropZonePath.length) {
+        const pathToItem = splitItemPath.slice(0, -1).join("-");
+        const currentItemIndex = Number(splitItemPath.at(-1));
+
+        const pathToDropZone = splitDropZonePath.slice(0, -1).join("-");
+        const currentDropZoneIndex = Number(splitDropZonePath.at(-1));
+
+        if (pathToItem === pathToDropZone) {
+          const nextDropZoneIndex = currentItemIndex + 1;
+          if (nextDropZoneIndex === currentDropZoneIndex) return false;
+        }
+      }
+
+      return true;
+    },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+    }),
+  });
+
+  const isActive = isOver && canDrop;
+
+  return (
+    <div
+      className={cn("dropZone", { active: isActive, isLast }, className)}
+      ref={drop as any}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DropZone;

--- a/src/app/(public)/blog/components/helper.ts
+++ b/src/app/(public)/blog/components/helper.ts
@@ -1,0 +1,113 @@
+import { Block } from "@/types/blog";
+
+function getBlockByPath(blocks: Block[], path: string): Block | null {
+  const indices = path.split("-").map(Number);
+  let current: Block | undefined;
+  let currentBlocks = blocks;
+
+  for (const index of indices) {
+    current = currentBlocks[index];
+    if (!current) return null;
+    currentBlocks = current.blocks;
+  }
+
+  return current || null;
+}
+
+function getParentAndIndex(
+  blocks: Block[],
+  path: string,
+): { parentBlocks: Block[]; index: number } | null {
+  const indices = path.split("-").map(Number);
+  if (indices.length === 0) return null;
+
+  const lastIndex = indices.pop()!;
+  let currentBlocks = blocks;
+
+  for (const index of indices) {
+    const current = currentBlocks[index];
+    if (!current) return null;
+    currentBlocks = current.blocks;
+  }
+
+  return { parentBlocks: currentBlocks, index: lastIndex };
+}
+
+function deleteBlockFromPath(blocks: Block[], path: string): boolean {
+  const parentInfo = getParentAndIndex(blocks, path);
+  if (!parentInfo) return false;
+
+  const { parentBlocks, index } = parentInfo;
+  if (index < 0 || index >= parentBlocks.length) return false;
+
+  parentBlocks.splice(index, 1);
+  return true;
+}
+
+export function insertBlockToPath(
+  blocks: Block[],
+  path: string,
+  blockToInsert: Block,
+): boolean {
+  console.log("🚀 ~ blocks:", blocks)
+  console.log("🚀 ~ blockToInsert:", blockToInsert)
+  console.log("🚀 ~ path:", path)
+  if (!path) return false;
+
+  const indices = path.split("-").map(Number);
+  const insertIndex = indices.pop(); // get last index (where to insert)
+  if (insertIndex === undefined) return false;
+
+  let currentBlocks = blocks;
+
+  for (const index of indices) {
+    const block = currentBlocks[index];
+    if (!block || !block.allowNesting) return false;
+    currentBlocks = block.blocks;
+  }
+  if (
+    !currentBlocks ||
+    insertIndex < 0 ||
+    insertIndex > currentBlocks.length + 1
+  )
+    return false;
+
+  currentBlocks.splice(insertIndex, 0, blockToInsert); // insert at exact position
+  return true;
+}
+
+// const cloneBlocks = (blocks: Block[]): Block[] => {
+//     return JSON.parse(JSON.stringify(blocks));
+//   };
+// const cloneBlocks = (blocks: Block[]): Block[] => {
+//     return cloned = structuredClone(blocks);
+//   };
+
+export function moveBlockFromPathToPath(
+  blocks: Block[],
+  fromPath: string,
+  toPath: string,
+): Block[] | null {
+  const clonedBlocks = structuredClone(blocks);
+
+  const blockToMove = getBlockByPath(clonedBlocks, fromPath);
+  if (!blockToMove) return null;
+
+  // 🟡 Get toPath parent block and target index BEFORE deleting
+  const toIndices = toPath.split("-").map(Number);
+  const insertIndex = toIndices[toIndices.length - 1];
+  const parentPath = toIndices.slice(0, -1).join("-");
+  const parentBlock = parentPath === "" ? { blocks: clonedBlocks } : getBlockByPath(clonedBlocks, parentPath);
+  if (!parentBlock || !Array.isArray(parentBlock.blocks)) return null;
+
+  // 🔴 Delete AFTER resolving target location
+  const deleted = deleteBlockFromPath(clonedBlocks, fromPath);
+  if (!deleted) return null;
+
+  // ✅ Now insert into pre-resolved parent block
+  parentBlock.blocks.splice(insertIndex, 0, blockToMove);
+
+  return clonedBlocks;
+}
+
+

--- a/src/app/(public)/blog/example.tsx
+++ b/src/app/(public)/blog/example.tsx
@@ -1,0 +1,226 @@
+"use client";
+import React, { useCallback, useEffect, useState } from "react";
+import { generateId } from "@/util";
+import { Block } from "@/types/blog";
+import { DraggableBlock } from "@/components/page-builder/DraggableBlock";
+import { addItem, deleteItem, duplicateItem, findItemById } from "@/util/blog";
+import DropZone from "./components/dropzone";
+import {
+  insertBlockToPath,
+  moveBlockFromPathToPath,
+} from "./components/helper";
+import { getBlockProps } from "@/constants/pagebuilder/blocks";
+import { blockStyles } from "./constants/blocks.styles";
+import { BlockForm, blocksForm } from "@/constants/pagebuilder/formFields";
+import FormModal from "@/components/form/FormModal/FormModal";
+
+type DropZoneData = {
+  path: string;
+  childrenCount: number;
+};
+
+type DraggedBlock = {
+  id: string;
+  path?: string;
+  type: Block["type"];
+};
+const Example: React.FC<{
+  blocks: Block[];
+  selectedBlock: Block | null;
+  setBlocks: React.Dispatch<React.SetStateAction<Block[]>>;
+  setSelectedBlock: React.Dispatch<React.SetStateAction<Block | null>>;
+}> = ({ blocks, setBlocks, selectedBlock, setSelectedBlock }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [copiedBlock, setCopiedBlock] = useState<Block | null>(null);
+
+  const [onHoldBlock, setOnHoldBlock] = useState(
+    {} as Block & { path: string },
+  );
+  const [formData, setFormData] = useState<BlockForm | null>(null);
+
+  const open = () => setIsModalOpen(true);
+  const close = () => setIsModalOpen(false);
+
+  const handleDrop = useCallback(
+    (dropZone: DropZoneData, draggableBlock: DraggedBlock) => {
+      console.log("dropZone", dropZone);
+      console.log("🚀 ~ draggableBlock:", draggableBlock);
+
+      if (!draggableBlock.path) {
+        handleAddBlock(draggableBlock.type, dropZone.path);
+        return;
+      }
+
+      const result = moveBlockFromPathToPath(
+        blocks,
+        draggableBlock.path,
+        dropZone.path,
+      );
+      if (result) setBlocks(result);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [blocks],
+  );
+
+  const handleSubmit = (data: Partial<Block>) => {
+    const newBlock = { ...onHoldBlock, ...data };
+    const clonedBlocks = structuredClone(blocks);
+    const inserted = insertBlockToPath(
+      clonedBlocks,
+      onHoldBlock.path,
+      newBlock,
+    );
+    if (!inserted) return null;
+    setBlocks(clonedBlocks);
+    close();
+  };
+
+  const handleAddBlock = (type: Block["type"], path: string, block?: Block) => {
+    const blockProps = getBlockProps(type, generateId());
+    const newBlock: Block = {
+      id: generateId(),
+      type,
+      level: 1,
+      blocks: [],
+      content: "",
+      styles: blockStyles[type],
+      ...blockProps,
+    };
+    const blockFormData = blocksForm.find((form) => form.type.includes(type));
+    if (blockFormData && blockFormData.isModal) {
+      open();
+      setFormData(blockFormData);
+      setOnHoldBlock({ ...newBlock, path });
+      return;
+    }
+    const clonedBlocks = structuredClone(blocks);
+    const inserted = insertBlockToPath(clonedBlocks, path, newBlock);
+    if (!inserted) return null;
+    setBlocks(clonedBlocks);
+    setSelectedBlock((pv) => (pv?.allowNesting ? pv : newBlock));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    // Check for Ctrl+C to copy features
+    if (e.ctrlKey && e.key === "c") {
+      if (selectedBlock) setCopiedBlock(selectedBlock);
+    }
+    if (e.ctrlKey && e.key === "x") {
+      if (selectedBlock) {
+        setCopiedBlock(selectedBlock);
+        setBlocks((blocks) => {
+          const newBlocks = structuredClone(blocks);
+          deleteItem(newBlocks, selectedBlock?.id);
+          return newBlocks;
+        });
+      }
+    }
+    if (e.key === "Delete") {
+      if (selectedBlock) {
+        setBlocks((blocks) => {
+          const newBlocks = structuredClone(blocks);
+          deleteItem(newBlocks, selectedBlock?.id);
+          return newBlocks;
+        });
+      }
+    }
+    if (e.ctrlKey && e.key === "d") {
+      if (selectedBlock) {
+        setBlocks((blocks) => {
+          const newBlocks = structuredClone(blocks);
+          const newBlock = duplicateItem(newBlocks, selectedBlock.id);
+          newBlock && setSelectedBlock(newBlock);
+          return newBlocks;
+        });
+      }
+    }
+    // Check for Ctrl+V to paste features
+    if (e.ctrlKey && e.key === "v") {
+      if (copiedBlock) {
+        const allowNesting =
+          selectedBlock &&
+          (selectedBlock?.allowNesting || selectedBlock?.parentId);
+        if (allowNesting) {
+          setBlocks((blocks) => {
+            const newBlocks = structuredClone(blocks);
+            copiedBlock.level = selectedBlock.level + 1;
+            copiedBlock.parentId = selectedBlock?.allowNesting
+              ? selectedBlock?.id
+              : selectedBlock?.parentId;
+            addItem(
+              newBlocks,
+              { ...copiedBlock, id: generateId() },
+              selectedBlock?.allowNesting
+                ? selectedBlock.id
+                : selectedBlock.parentId,
+            );
+            return newBlocks;
+          });
+        } else {
+          setBlocks((pv) => [...pv, { ...copiedBlock, id: generateId() }]);
+        }
+        setSelectedBlock((pv) =>
+          pv?.allowNesting ? pv : { ...copiedBlock, id: generateId() },
+        );
+      }
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedBlock]);
+
+  return (
+    <div className="flex flex-col h-full flex-grow">
+      {formData && (
+        <FormModal
+          open={isModalOpen}
+          onClose={close}
+          onSubmit={handleSubmit}
+          {...formData}
+        />
+      )}
+      {blocks.map((block, index) => {
+        const currentPath = `${index}`;
+        return (
+          <React.Fragment key={block.id}>
+            <DropZone
+              data={{
+                path: currentPath,
+                childrenCount: blocks.length,
+              }}
+              onDrop={handleDrop}
+            />
+            <DraggableBlock
+              key={block.id}
+              block={block}
+              handleDrop={handleDrop}
+              path={currentPath}
+              selectedBlock={
+                selectedBlock?.id
+                  ? findItemById(blocks, selectedBlock?.id)
+                  : undefined
+              }
+              onSelect={setSelectedBlock}
+              setBlocks={setBlocks}
+            />
+          </React.Fragment>
+        );
+      })}
+      <DropZone
+        data={{
+          path: `${blocks.length}`,
+          childrenCount: blocks.length,
+        }}
+        onDrop={handleDrop}
+        isLast
+        className="!h-full min-h-12 flex-grow"
+      />
+    </div>
+  );
+};
+export default Example;

--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -1,14 +1,17 @@
 "use client";
-import { useState } from "react";
-import { DragDropContext, Droppable, DropResult } from "@hello-pangea/dnd";
+import { useEffect, useState } from "react";
 import { ViewModeSelector } from "@/components/page-builder/ViewModeSelector";
-import { DraggableBlock } from "@/components/page-builder/DraggableBlock";
 import ToolBar from "./toolbar";
 import { Block, BlogSettings } from "@/types/blog";
 import EditorHeader from "./EditorHeader";
 import { findItemById } from "@/util/blog";
-import { onDragEndHandler } from "./blog";
 import ArticlePreview from "./blogReview";
+
+import "./styles.css";
+
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import Example from "./example";
 
 type ViewMode = "desktop" | "tablet" | "mobile";
 
@@ -38,34 +41,8 @@ export default function PageBuilder() {
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [selectedBlock, setSelectedBlock] = useState<Block | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("desktop");
-
   const [onPreview, setPreview] = useState(false);
-
-  const onDragEnd = (result: any) => {
-    const newBlocks = onDragEndHandler(blocks, result);
-    setBlocks(newBlocks);
-    // const { source, draggableId, destination, type } = result;
-
-    // if (!destination) return;
-
-    // destination.droppableId = destination.droppableId.replace("drop-", "");
-    // source.droppableId = source.droppableId.replace("drop-", "");
-
-    // if (type === "ROOT") {
-    //   const newBlocks = [...blocks];
-    //   const [movedBlock] = newBlocks.splice(source.index, 1);
-    //   newBlocks.splice(destination.index, 0, movedBlock);
-    //   setBlocks(newBlocks);
-    //   return;
-    // }
-    // const newBlocks = onDragEndHandler(
-    //   blocks,
-    //   draggableId,
-    //   source,
-    //   destination,
-    // );
-    // setBlocks(newBlocks);
-  };
+  
 
   return (
     <div>
@@ -74,73 +51,58 @@ export default function PageBuilder() {
         onPreview={onPreview}
         setPreview={setPreview}
       />
-      <div className="flex bg-background">
-        <main className="max-w-full flex-1 overflow-hidden">
-          <div className="flex max-h-[50px] items-center justify-center border-b border-gray-200 p-4">
-            <ViewModeSelector
-              viewMode={viewMode}
-              onViewModeChange={setViewMode}
-            />
-          </div>
-          {/* Header Section */}
-
-          {/* Content Area */}
-          <div
-            className={`scroll-bar-minimal h-[calc(100vh-132px)] overflow-auto bg-gray-50 p-4`}
-          >
-            <div
-              onClick={() => {
-                setSelectedBlock(null);
-              }}
-              className={`mx-auto min-h-full border bg-white p-2 shadow-soft transition-all ${getViewModeWidth(viewMode)}`}
-            >
-              {onPreview ? (
-                <ArticlePreview blocks={blocks} />
-              ) : (
-                <DragDropContext onDragEnd={onDragEnd}>
-                  <Droppable droppableId="root" type="BLOCK">
-                    {(provided) => (
-                      <div {...provided.droppableProps} ref={provided.innerRef}>
-                        {blocks.map((block, index) => (
-                          <DraggableBlock
-                            key={block.id}
-                            block={block}
-                            index={index}
-                            selectedBlock={
-                              selectedBlock?.id
-                                ? findItemById(blocks, selectedBlock?.id)
-                                : undefined
-                            }
-                            onSelect={setSelectedBlock}
-                            setBlocks={setBlocks}
-                          />
-                        ))}
-                        {provided.placeholder}
-                      </div>
-                    )}
-                  </Droppable>
-                </DragDropContext>
-              )}
+      <DndProvider backend={HTML5Backend}>
+        <div className="flex bg-background">
+          <main className="max-w-full flex-1 overflow-hidden">
+            <div className="flex max-h-[50px] items-center justify-center border-b border-gray-200 p-4">
+              <ViewModeSelector
+                viewMode={viewMode}
+                onViewModeChange={setViewMode}
+              />
             </div>
-          </div>
-        </main>
+            {/* Header Section */}
 
-        {/* Toolbars and Menus */}
-        {!onPreview && (
-          <ToolBar
-            blocks={blocks}
-            setBlocks={setBlocks}
-            selectedBlock={
-              selectedBlock?.id
-                ? findItemById(blocks, selectedBlock?.id)
-                : undefined
-            }
-            settings={settings}
-            updateSettings={setSettings}
-            setSelectedBlock={setSelectedBlock}
-          />
-        )}
-      </div>
+            {/* Content Area */}
+            <div
+              className={`scrollable-container scroll-bar-minimal !pointer-events-auto h-[calc(100vh-132px)] !overflow-auto bg-gray-50 p-4`}
+            >
+              <div
+                onClick={() => {
+                  setSelectedBlock(null);
+                }}
+                className={`mx-auto flex flex-col min-h-full border bg-white p-2 shadow-soft transition-all ${getViewModeWidth(viewMode)}`}
+              >
+                {onPreview ? (
+                  <ArticlePreview blocks={blocks} />
+                ) : (
+                  <Example
+                    blocks={blocks}
+                    selectedBlock={selectedBlock}
+                    setBlocks={setBlocks}
+                    setSelectedBlock={setSelectedBlock}
+                  />
+                )}
+              </div>
+            </div>
+          </main>
+
+          {/* Toolbars and Menus */}
+          {!onPreview && (
+            <ToolBar
+              blocks={blocks}
+              setBlocks={setBlocks}
+              selectedBlock={
+                selectedBlock?.id
+                  ? findItemById(blocks, selectedBlock?.id)
+                  : undefined
+              }
+              settings={settings}
+              updateSettings={setSettings}
+              setSelectedBlock={setSelectedBlock}
+            />
+          )}
+        </div>
+      </DndProvider>
     </div>
   );
 }

--- a/src/app/(public)/blog/styles.css
+++ b/src/app/(public)/blog/styles.css
@@ -1,0 +1,29 @@
+.dropZone {
+  flex: 0 0 auto;
+  height: 20px;
+  /* background: #00a2ff3d; */
+  transition: 200ms all;
+}
+
+.dropZone:nth-of-type(2n) {
+  display: none;
+}
+.dropZone.horizontalDrag {
+  width: 20px;
+  height: auto;
+}
+
+.dropZone:not(.horizontalDrag).isLast {
+  flex: 1 1 auto;
+}
+
+.dropZone:not(.horizontalDrag).active {
+  background: #8181811f;
+  transition: 100ms all;
+  height: 100px;
+}
+.dropZone.horizontalDrag.active {
+  background: #8181811f;
+  transition: 100ms all;
+  width: 100px;
+}

--- a/src/components/page-builder/BlockOptions.tsx
+++ b/src/components/page-builder/BlockOptions.tsx
@@ -3,19 +3,19 @@ import { BlockAction } from "@/types/pageBuilder";
 import { DragIndicator } from "@mui/icons-material";
 import { IconButton, Tooltip } from "@mui/material";
 import { ContentCopy, DeleteOutline } from "@mui/icons-material";
-import { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd";
 import { deleteItem, duplicateItem } from "@/util/blog";
+import { RefObject } from "react";
 
 interface BlockOptionsProps {
   block: Block;
-  provided: DraggableProvidedDragHandleProps | null;
+  dragRef: RefObject<HTMLDivElement>;
   selectedBlock?: Block | null;
   onSelect: (block: Block) => void;
   setBlocks: React.Dispatch<React.SetStateAction<Block[]>>;
 }
 
 const BlockOptions: React.FC<BlockOptionsProps> = ({
-  provided,
+  dragRef,
   setBlocks,
   onSelect,
   selectedBlock,
@@ -43,22 +43,19 @@ const BlockOptions: React.FC<BlockOptionsProps> = ({
     }
   };
 
-
   return (
     <div
       style={{ zIndex: 20 - block.level }}
       aria-selected={isSelected}
-      className={`group/button absolute -right-4 top-1/2 mr-4  -translate-y-1/2 translate-x-1/2 flex-row-reverse rounded-base bg-gray-800 p-1  transition-all duration-500 hover:right-5 hidden aria-selected:flex`}
+      className={`group/button absolute -right-4 top-1/2 mr-4 hidden -translate-y-1/2 translate-x-1/2 flex-row-reverse rounded-base bg-gray-800 p-1 transition-all duration-500 hover:right-5 aria-selected:flex`}
     >
-      <Tooltip placement="top" arrow title="Drag to Reorder">
-        <IconButton
-          {...provided}
-          className="rounded-base p-1 hover:bg-black"
-          tabIndex={-1}
-        >
-          <DragIndicator className="h-5 w-5 cursor-move text-white" />
-        </IconButton>
-      </Tooltip>
+      <div
+        ref={dragRef}
+        className="rounded-base p-1 hover:bg-black"
+        tabIndex={-1}
+      >
+        <DragIndicator className="h-5 w-5 cursor-move text-white" />
+      </div>
       <div className="w-fit max-w-0 gap-1 overflow-hidden transition-all duration-500 group-hover/button:max-w-40">
         <div className="flex min-w-fit gap-1">
           <Tooltip placement="top" arrow title="Duplicate Block">

--- a/src/components/page-builder/DraggableBlock.tsx
+++ b/src/components/page-builder/DraggableBlock.tsx
@@ -1,56 +1,91 @@
-import { Draggable } from "@hello-pangea/dnd";
 import { Block } from "@/types/blog";
 import { BlockRenderer } from "./BlockRenderer";
 import BlockOptions from "./BlockOptions";
+import { useEffect, useRef } from "react";
+import { useDrag } from "react-dnd";
+import { useAutoScrollOnDrag } from "@/hooks/useAutoScrollOnDrag";
+
+type DropZoneData = {
+  path: string;
+  childrenCount: number;
+};
+
+type DragItem = Block & { path: string };
 
 interface DraggableBlockProps {
   block: Block;
-  index: number;
   selectedBlock?: Block | null;
   onSelect: (block: Block) => void;
   setBlocks: React.Dispatch<React.SetStateAction<Block[]>>;
+  handleDrop: (data: DropZoneData, item: DragItem) => void;
+  path: string;
 }
 
 export function DraggableBlock({
   block,
-  index,
   selectedBlock,
   onSelect,
   setBlocks,
+  handleDrop,
+  path,
 }: DraggableBlockProps) {
   const isSelected = selectedBlock?.id === block.id;
 
+  const dragRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+
+  const [{ isDragging }, drag, preview] = useDrag({
+    type: block.type,
+    item: {
+      type: block.type,
+      id: block.id,
+      children: block.blocks,
+      path,
+    },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  });
+
+  const opacity = isDragging ? 0 : 1;
+
+  drag(dragRef);
+  preview(previewRef);
+
+  useAutoScrollOnDrag({
+    isDragging,
+    className: ".scrollable-container",
+  });
+
   return (
-    <Draggable draggableId={block.id} index={index}>
-      {(provided) => (
-        <div
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          onClick={(e) => {
-            e.stopPropagation();
-            onSelect(block);
-          }}
-          className={`relative w-full rounded-base border p-2 ${
-            isSelected
-              ? "border-primary"
-              : "border-transparent hover:border-neutral-400"
-          }`}
-        >
-          <BlockOptions
-            block={block}
-            onSelect={onSelect}
-            setBlocks={setBlocks}
-            selectedBlock={selectedBlock}
-            provided={provided.dragHandleProps}
-          />
-          <BlockRenderer
-            block={block}
-            onSelect={onSelect}
-            selectedBlock={selectedBlock}
-            setBlocks={setBlocks}
-          />
-        </div>
-      )}
-    </Draggable>
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect(block);
+      }}
+      ref={previewRef}
+      style={{ opacity }}
+      className={`relative w-full rounded-base border p-2 ${
+        isSelected
+          ? "border-primary"
+          : "border-transparent hover:border-neutral-400"
+      }`}
+    >
+      <BlockOptions
+        block={block}
+        onSelect={onSelect}
+        setBlocks={setBlocks}
+        selectedBlock={selectedBlock}
+        dragRef={dragRef}
+      />
+      <BlockRenderer
+        block={block}
+        onSelect={onSelect}
+        selectedBlock={selectedBlock}
+        handleDrop={handleDrop}
+        setBlocks={setBlocks}
+        path={path}
+      />
+    </div>
   );
 }

--- a/src/hooks/useAutoScrollOnDrag.ts
+++ b/src/hooks/useAutoScrollOnDrag.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+
+type AutoScrollOptions = {
+  isDragging: boolean;
+  className: string;
+  padding?: number;
+  speed?: number;
+};
+
+export function useAutoScrollOnDrag({
+  isDragging,
+  className,
+  padding = 50,
+  speed = 10,
+}: AutoScrollOptions) {
+  const animationFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const scrollContainer = document.querySelector<HTMLElement>(className);
+    if (!scrollContainer) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const { top, bottom } = scrollContainer.getBoundingClientRect();
+
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+
+      animationFrameRef.current = requestAnimationFrame(() => {
+        if (e.clientY < top + padding) {
+          scrollContainer.scrollTop -= speed;
+        } else if (e.clientY > bottom - padding) {
+          scrollContainer.scrollTop += speed;
+        }
+      });
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [isDragging, className, padding, speed]);
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -28,11 +28,6 @@ export interface Block {
   blocks: Block[];
   level: number;
   allowNesting?: boolean;
-  gridProps?: {
-    xs?: number;
-    sm?: number;
-    md?: number;
-  };
 }
 
 export type BlogSettings = {


### PR DESCRIPTION
This commit introduces drag and drop functionality to the blog editor, allowing users to reorder blocks within the editor interface.

- Integrated `react-dnd` and `react-dnd-html5-backend` for drag and drop support.
- Replaced `@hello-pangea/dnd` with `react-dnd` for block reordering.
- Implemented `useDrag` and `useDrop` hooks in `DraggableBlock.tsx` and `BlockRenderer.tsx` to enable dragging and dropping of blocks.
- Added `DropZone` component to visually represent drop targets within containers and flex rows.
- Implemented `handleDrop` function to manage block reordering logic.
- Added `useAutoScrollOnDrag` hook to automatically scroll the editor content during drag operations.
- Removed gridProps from Block interface.
- Added console logs for debugging purposes in `blog.ts`.
- Refactored `BlockOptions` to use a ref for the drag handle instead of props from `@hello-pangea/dnd`.
- Added `AddBlockItem` component to `blocksPanel.tsx` to enable dragging new blocks from the panel.
- Added `styles.css` to handle global styles.